### PR TITLE
Update StringExtensions.cs

### DIFF
--- a/src/DynamicDriver.cs
+++ b/src/DynamicDriver.cs
@@ -199,11 +199,13 @@ namespace NY.Dataverse.LINQPadDriver
                                                                     var enumValue = x.SanitisedLabel;
                                                                     if (string.IsNullOrEmpty(x.SanitisedLabel))
                                                                     {
-                                                                        enumValue = $"_{x.Value}";
+																		//When the value is a negative number, replace '-' with '_'.
+																		enumValue = $"_{x.Value}".Replace("-","_");
                                                                     }
                                                                     else if (IsCSharpKeyword(enumValue) || char.IsDigit(enumValue[0]) || allOptions.Count(o => o.SanitisedLabel == x.SanitisedLabel) > 1)
                                                                     {
-                                                                        enumValue = $"_{enumValue}_{x.Value}";
+																		//When the value is a negative number, replace '-' with '_'.
+																		enumValue = $"_{enumValue}_{x.Value}".Replace("-", "_");
                                                                     }
                                                                     return (Label: enumValue, x.Value);
                                                                 }).ToList())).ToList()

--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -2,14 +2,22 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.CSharp;
 
 namespace NY.Dataverse.LINQPadDriver
 {
     public static class StringExtensions
     {
+        private static readonly CSharpCodeProvider _csharpCodeProvider = new CSharpCodeProvider();
+
         public static string Sanitise(this string input)
         {
-            return new Regex("[^a-zA-Z0-9_\u4e00-\u9fa5a]").Replace(string.Join("_", input.Split(" ")), "");
+            var joinedInput = string.Join("_", input.Split(" "));
+            if (_csharpCodeProvider.IsValidIdentifier(joinedInput))
+            {
+                return joinedInput;
+            }
+            return new Regex("[^a-zA-Z0-9_]").Replace(joinedInput, "");
         }
     }
 }

--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace NY.Dataverse.LINQPadDriver
     {
         public static string Sanitise(this string input)
         {
-            return new Regex("[^a-zA-Z0-9_]").Replace(string.Join("_", input.Split(" ")), "");
+            return new Regex("[^a-zA-Z0-9_\u4e00-\u9fa5a]").Replace(string.Join("_", input.Split(" ")), "");
         }
     }
 }


### PR DESCRIPTION
Fix: string sanitise

My dataverse environment uses chinese as the default language. 
When `ServiceClient` connects successfully, compiling `LINQPad.EarlyBound.cs` with metadata will fail.

![image](https://user-images.githubusercontent.com/13699353/143572706-ead6610e-960c-4a60-9858-938ac86ca289.png)

Because the chinese character sets will be replace empty string. `CompileSource` will fail to compile.

![image](https://user-images.githubusercontent.com/13699353/143571561-b7c78cc3-69d4-482b-8253-a009b4547e5c.png)

C# supports using chinese as variable names. By allowing chinese character sets, the compilation is now successful.

![image](https://user-images.githubusercontent.com/13699353/143571871-33822d9a-abd7-46d2-a3ce-0a05aa5f5ea3.png)
